### PR TITLE
Added support for mutable-content flag in aps

### DIFF
--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -341,16 +341,19 @@ class Aps(object):
         sound: Name of the sound file to be played with the message (optional).
         content_available: A boolean indicating whether to configure a background update
             notification (optional).
+        mutable_content: A boolean indicating whether to have the message be mutable
+            on device before final delivery (optional).
         category: String identifier representing the message type (optional).
         thread_id: An app-specific string identifier for grouping messages (optional).
     """
 
-    def __init__(self, alert=None, badge=None, sound=None, content_available=None, category=None,
-                 thread_id=None):
+    def __init__(self, alert=None, badge=None, sound=None, content_available=None,
+                 mutable_content=None, category=None, thread_id=None):
         self.alert = alert
         self.badge = badge
         self.sound = sound
         self.content_available = content_available
+        self.mutable_content = mutable_content
         self.category = category
         self.thread_id = thread_id
 
@@ -624,6 +627,8 @@ class _MessageEncoder(json.JSONEncoder):
         }
         if aps.content_available is True:
             result['content-available'] = 1
+        if aps.mutable_content is True:
+            result['mutable-content'] = 1
         return cls.remove_null_values(result)
 
     @classmethod

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -597,6 +597,7 @@ class TestApsEncoder(object):
                         badge=42,
                         sound='s',
                         content_available=True,
+                        mutable_content=True,
                         category='c',
                         thread_id='t'
                     ),
@@ -612,6 +613,7 @@ class TestApsEncoder(object):
                         'badge': 42,
                         'sound': 's',
                         'content-available': 1,
+                        'mutable-content': 1,
                         'category': 'c',
                         'thread-id': 't',
                     },


### PR DESCRIPTION
This adds an additional flag to the Aps class to support mutable notifications: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ModifyingNotifications.html
